### PR TITLE
feat: add sqlite init script and update docs

### DIFF
--- a/FIXES_SUMMARY.md
+++ b/FIXES_SUMMARY.md
@@ -78,7 +78,7 @@
 
 ### 1. Инициализация
 ```bash
-node scripts/init-sqlite.cjs
+npm run init-sqlite
 ```
 
 ### 2. Запуск проекта

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install
 
 ### 2. Инициализация SQLite базы данных
 ```bash
-node scripts/init-sqlite.cjs
+npm run init-sqlite
 ```
 
 ### 3. Запуск проекта
@@ -55,7 +55,7 @@ src/
 
 1. **Проверьте импорты** - все пути должны быть корректными
 2. **Убедитесь, что все типы определены** в `src/types/`
-3. **Проверьте, что моковые данные созданы** через `node scripts/init-sqlite.cjs`
+3. **Проверьте, что моковые данные созданы** через `npm run init-sqlite`
 
 ### Проблема: База данных не загружается
 Если данные не загружаются:
@@ -63,7 +63,7 @@ src/
 1. **Проверьте, что файл `src/data/mock-data.json` существует**
 2. **Пересоздайте данные:**
    ```bash
-   node scripts/init-sqlite.cjs
+   npm run init-sqlite
    ```
 
 ## 🗄️ SQLite интеграция
@@ -137,7 +137,7 @@ console.log('Categories:', categories);
 ### Изменение структуры данных:
 1. Обновите интерфейсы в `src/types/product.ts`
 2. Обновите моковые данные
-3. Пересоздайте данные: `node scripts/init-sqlite.cjs`
+3. Пересоздайте данные: `npm run init-sqlite`
 
 ## ✅ Статус проекта
 

--- a/SQLITE_SETUP.md
+++ b/SQLITE_SETUP.md
@@ -8,7 +8,7 @@
 
 ### 1. База данных SQLite
 - **Файл**: `database.db` (создается автоматически)
-- **Скрипт инициализации**: `scripts/init-sqlite.js`
+- **Скрипт инициализации**: `scripts/init-sqlite.cjs`
 - **Класс базы данных**: `src/data/sqlite/database.ts`
 
 ### 2. API для работы с данными

--- a/scripts/init-sqlite.cjs
+++ b/scripts/init-sqlite.cjs
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const initSqlJs = require('sql.js');
+
+async function initSQLite() {
+  try {
+    const SQL = await initSqlJs();
+    const dbPath = path.join(process.cwd(), 'database.db');
+    const db = fs.existsSync(dbPath)
+      ? new SQL.Database(fs.readFileSync(dbPath))
+      : new SQL.Database();
+
+    db.run(`
+      CREATE TABLE IF NOT EXISTS categories (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        imageUrl TEXT,
+        created_at TEXT,
+        updated_at TEXT
+      );
+      CREATE TABLE IF NOT EXISTS products (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        price REAL NOT NULL,
+        category TEXT,
+        imageUrl TEXT,
+        rating REAL,
+        inStock INTEGER,
+        stockQuantity INTEGER,
+        archived INTEGER,
+        isNew INTEGER,
+        isBestseller INTEGER
+      );
+    `);
+
+    const dataPath = path.join(__dirname, '../src/data/mock-data.json');
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+
+    const insertCategory = db.prepare(
+      'INSERT OR REPLACE INTO categories (id, name, description, imageUrl, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+    );
+    data.categories.forEach((c) => {
+      insertCategory.run([
+        c.id,
+        c.name,
+        c.description || null,
+        c.imageUrl || null,
+        c.created_at || null,
+        c.updated_at || null,
+      ]);
+    });
+    insertCategory.free();
+
+    const insertProduct = db.prepare(
+      'INSERT OR REPLACE INTO products (id, title, description, price, category, imageUrl, rating, inStock, stockQuantity, archived, isNew, isBestseller) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    data.products.forEach((p) => {
+      insertProduct.run([
+        p.id,
+        p.title,
+        p.description || null,
+        p.price,
+        p.category,
+        p.imageUrl || null,
+        p.rating || null,
+        p.inStock ? 1 : 0,
+        p.stockQuantity || 0,
+        p.archived ? 1 : 0,
+        p.isNew ? 1 : 0,
+        p.isBestseller ? 1 : 0,
+      ]);
+    });
+    insertProduct.free();
+
+    const buffer = Buffer.from(db.export());
+    fs.writeFileSync(dbPath, buffer);
+    console.log('SQLite database initialized at', dbPath);
+  } catch (err) {
+    console.error('Failed to initialize SQLite database:', err);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  initSQLite();
+}
+
+module.exports = initSQLite;


### PR DESCRIPTION
## Summary
- add `init-sqlite` script to create and seed SQLite database from mock data
- document using `npm run init-sqlite` for database initialization

## Testing
- `npm test` *(fails: Missing script)*
- `npm run init-sqlite`


------
https://chatgpt.com/codex/tasks/task_e_68a88b8aea688323a408b4e8d5805451