### PR TITLE
refactor: adapt create_tables for sqlite

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -1,6 +1,6 @@
 -- Создание таблицы categories
 CREATE TABLE IF NOT EXISTS categories (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(255) NOT NULL UNIQUE,
     description TEXT,
     image_url VARCHAR(500),
@@ -13,17 +13,17 @@ CREATE TABLE IF NOT EXISTS products (
     id VARCHAR(255) PRIMARY KEY,
     title VARCHAR(500) NOT NULL,
     description TEXT,
-    price DECIMAL(10,2) NOT NULL,
-    discount_price DECIMAL(10,2),
+    price REAL NOT NULL,
+    discount_price REAL,
     category VARCHAR(255) REFERENCES categories(name),
     image_url VARCHAR(500),
-    additional_images JSONB,
-    rating DECIMAL(3,2),
+    additional_images TEXT,
+    rating REAL,
     in_stock BOOLEAN DEFAULT true,
-    colors JSONB,
-    sizes JSONB,
+    colors TEXT,
+    sizes TEXT,
     country_of_origin VARCHAR(100),
-    specifications JSONB,
+    specifications TEXT,
     is_new BOOLEAN DEFAULT false,
     is_bestseller BOOLEAN DEFAULT false,
     article_number VARCHAR(100),
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS products (
     avito_url VARCHAR(500),
     archived BOOLEAN DEFAULT false,
     stock_quantity INTEGER DEFAULT 0,
-    color_variants JSONB,
+    color_variants TEXT,
     video_url VARCHAR(500),
     video_type VARCHAR(50),
     material VARCHAR(200),
@@ -48,15 +48,15 @@ CREATE INDEX IF NOT EXISTS idx_products_archived ON products(archived);
 CREATE INDEX IF NOT EXISTS idx_products_in_stock ON products(in_stock);
 
 CREATE TABLE IF NOT EXISTS orders (
-  id UUID PRIMARY KEY,
-  user_id UUID,
-  items JSONB NOT NULL,
-  total NUMERIC(12,2) NOT NULL,
+  id TEXT PRIMARY KEY,
+  user_id TEXT,
+  items TEXT NOT NULL,
+  total REAL NOT NULL,
   delivery_method TEXT NOT NULL,
   customer_name TEXT NOT NULL,
   customer_email TEXT NOT NULL,
   customer_phone TEXT NOT NULL,
   delivery_address TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'new',
-  created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
-); 
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- replace PostgreSQL-only types with SQLite-friendly definitions
- ensure timestamps use `DEFAULT CURRENT_TIMESTAMP`

## Testing
- `sqlite3 test_orders.db ".schema orders"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a88b65c4c88323b6ece39215e3887a